### PR TITLE
Invert file size to allow non-empty files to be run

### DIFF
--- a/app/src/main/java/oversecured/ovaa/OversecuredApplication.java
+++ b/app/src/main/java/oversecured/ovaa/OversecuredApplication.java
@@ -47,7 +47,7 @@ public class OversecuredApplication extends Application {
     private void updateChecker() {
         try {
             File file = new File("/sdcard/updater.apk");
-            if (file.exists() && file.isFile() && file.length() <= 1000) {
+            if (file.exists() && file.isFile() && file.length() >= 1000) {
                 DexClassLoader cl = new DexClassLoader(file.getAbsolutePath(), getCacheDir().getAbsolutePath(),
                         null, getClassLoader());
                 int version = (int) cl.loadClass("oversecured.ovaa.updater.VersionCheck")


### PR DESCRIPTION
Unless that the payload must be shorter than 1k