### PR TITLE
Add build & release debug APK workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,58 @@
+name: Build & Release Debug APK
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  apk:
+    name: Generate APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Build APK
+        run: bash ./gradlew assembleDebug --stacktrace
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v1
+        with:
+          name: apk
+          path: app/build/outputs/apk/debug/app-debug.apk
+
+  release:
+    name: Release APK
+    needs: apk
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download APK from build
+        uses: actions/download-artifact@v1
+        with:
+          name: apk
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref_name }}
+
+      - name: Upload Release APK
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: apk/app-debug.apk
+          asset_name: ovaa-${{ github.ref_name }}.apk
+          asset_content_type: application/zip

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020, Oversecured Inc
+Copyright (c) 2022, Oversecured Inc
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ This section only includes the list of vulnerabilities, without a detailed descr
 ---------------------------------------
 *Licensed under the Simplified BSD License*
 
-*Copyright (c) 2020, Oversecured Inc*
+*Copyright (c) 2022, Oversecured Inc*
 
 https://oversecured.com/


### PR DESCRIPTION
To make it easier to get the pre-built APK directly from the release page. Example release, see https://github.com/dwisiswant0/ovaa/releases/tag/v1.0.0.